### PR TITLE
Return correct error for NoTransitionError

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -273,7 +273,7 @@ func (f *FSM) Event(event string, args ...interface{}) error {
 
 	if f.current == dst {
 		f.afterEventCallbacks(e)
-		return &NoTransitionError{e.Err}
+		return NoTransitionError{e.Err}
 	}
 
 	// Setup the transition, call it later.

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -587,6 +587,20 @@ func TestDoubleTransition(t *testing.T) {
 	wg.Wait()
 }
 
+func TestNoTransition(t *testing.T) {
+	fsm := NewFSM(
+		"start",
+		Events{
+			{Name: "run", Src: []string{"start"}, Dst: "start"},
+		},
+		Callbacks{},
+	)
+	err := fsm.Event("run")
+	if _, ok := err.(NoTransitionError); !ok {
+		t.Error("expected 'NoTransitionError'")
+	}
+}
+
 func ExampleNewFSM() {
 	fsm := NewFSM(
 		"green",


### PR DESCRIPTION
for same state transition return NoTransitionError{} instead of &NoTransitionError{}