### PR TITLE
Add SetState to modify the current state

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -212,6 +212,14 @@ func (f *FSM) Is(state string) bool {
 	return state == f.current
 }
 
+// SetState allows the user to move to the given state from current state.
+func (f *FSM) SetState(state string) {
+	f.stateMu.Lock()
+	defer f.stateMu.Unlock()
+	f.current = state
+	return
+}
+
 // Can returns true if event can occur in the current state.
 func (f *FSM) Can(event string) bool {
 	f.stateMu.RLock()

--- a/fsm.go
+++ b/fsm.go
@@ -213,6 +213,7 @@ func (f *FSM) Is(state string) bool {
 }
 
 // SetState allows the user to move to the given state from current state.
+// The call does not trigger any callbacks, if defined.
 func (f *FSM) SetState(state string) {
 	f.stateMu.Lock()
 	defer f.stateMu.Unlock()

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -42,6 +42,24 @@ func TestSameState(t *testing.T) {
 	}
 }
 
+func TestSetState(t *testing.T) {
+	fsm := NewFSM(
+		"walking",
+		Events{
+			{Name: "walk", Src: []string{"start"}, Dst: "walking"},
+		},
+		Callbacks{},
+	)
+	fsm.SetState("start")
+	if fsm.Current() != "start" {
+		t.Error("expected state to be 'walking'")
+	}
+	err := fsm.Event("walk")
+	if err != nil {
+		t.Error("transition is expected no error")
+	}
+}
+
 func TestBadTransition(t *testing.T) {
 	fsm := NewFSM(
 		"start",


### PR DESCRIPTION
For some cases, instead of maintaining the state changes, we only need the state diagram. In other words, we allow callers to maintain the state change. Therefore, we allow the caller to modify the current state, so we can jump to a specific state in anytime. In other cases, by opening this API, we can easily implement test cases in different states.