### PR TITLE
Allow validating transitions without triggering event

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -213,11 +213,18 @@ func (f *FSM) Is(state string) bool {
 }
 
 // Can returns true if event can occur in the current state.
-func (f *FSM) Can(event string) bool {
+func (f *FSM) Can(event string, args ...interface{}) bool {
 	f.stateMu.RLock()
 	defer f.stateMu.RUnlock()
-	_, ok := f.transitions[eKey{event, f.current}]
-	return ok && (f.transition == nil)
+	dst, ok := f.transitions[eKey{event, f.current}]
+
+	if !ok || (f.transition != nil) {
+		return false
+	}
+
+	e := &Event{f, event, f.current, dst, nil, args, false, false}
+	err := f.beforeEventCallbacks(e)
+	return err == nil
 }
 
 // Cannot returns true if event can not occure in the current state.

--- a/fsm.go
+++ b/fsm.go
@@ -213,24 +213,25 @@ func (f *FSM) Is(state string) bool {
 }
 
 // Can returns true if event can occur in the current state.
-func (f *FSM) Can(event string, args ...interface{}) bool {
+func (f *FSM) Can(event string, args ...interface{}) (bool, error) {
 	f.stateMu.RLock()
 	defer f.stateMu.RUnlock()
 	dst, ok := f.transitions[eKey{event, f.current}]
 
 	if !ok || (f.transition != nil) {
-		return false
+		return false, nil
 	}
 
 	e := &Event{f, event, f.current, dst, nil, args, false, false}
 	err := f.beforeEventCallbacks(e)
-	return err == nil
+	return err == nil, err
 }
 
 // Cannot returns true if event can not occure in the current state.
 // It is a convenience method to help code read nicely.
-func (f *FSM) Cannot(event string) bool {
-	return !f.Can(event)
+func (f *FSM) Cannot(event string) (bool, error) {
+	ok, err := f.Can(event)
+	return !ok, err
 }
 
 // Event initiates a state transition with the named event.

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -615,7 +615,7 @@ func TestCanWithInvalidEvent(t *testing.T) {
 			},
 		},
 	)
-	if fsm.Can("open") {
+	if ok, _ := fsm.Can("open"); ok {
 		t.Error("Should not be able to open")
 	}
 }
@@ -717,8 +717,8 @@ func ExampleFSM_Can() {
 	fmt.Println(fsm.Can("open"))
 	fmt.Println(fsm.Can("close"))
 	// Output:
-	// true
-	// false
+	// true <nil>
+	// false <nil>
 }
 
 func ExampleFSM_Cannot() {
@@ -733,8 +733,8 @@ func ExampleFSM_Cannot() {
 	fmt.Println(fsm.Cannot("open"))
 	fmt.Println(fsm.Cannot("close"))
 	// Output:
-	// false
-	// true
+	// false <nil>
+	// true <nil>
 }
 
 func ExampleFSM_Event() {

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -15,6 +15,7 @@
 package fsm
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -598,6 +599,24 @@ func TestNoTransition(t *testing.T) {
 	err := fsm.Event("run")
 	if _, ok := err.(NoTransitionError); !ok {
 		t.Error("expected 'NoTransitionError'")
+	}
+}
+
+func TestCanWithInvalidEvent(t *testing.T) {
+	fsm := NewFSM(
+		"closed",
+		Events{
+			{Name: "open", Src: []string{"closed"}, Dst: "open"},
+			{Name: "close", Src: []string{"open"}, Dst: "closed"},
+		},
+		Callbacks{
+			"before_open": func(e *Event) {
+				e.Cancel(errors.New("Is locked"))
+			},
+		},
+	)
+	if fsm.Can("open") {
+		t.Error("Should not be able to open")
 	}
 }
 


### PR DESCRIPTION
Hi,

Wanted the check for valid transitions to include the before callbacks - I think similar to suggestion in #10.
My changes break the existing interface for Can/Cannot so maybe not something that you would want to merge as it is, but any thoughts on whether you think this functionality would be useful and if so, what changes you would need to the PR before accepting?

Thanks

Alastair
