### PR TITLE
Added an AvailableTransitions func to FSM

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -229,6 +229,20 @@ func (f *FSM) Can(event string) bool {
 	return ok && (f.transition == nil)
 }
 
+// AvailableTransitions returns a list of transitions avilable in the
+// current state.
+func (f *FSM) AvailableTransitions() []string {
+	f.stateMu.RLock()
+	defer f.stateMu.RUnlock()
+	var transitions []string
+	for key := range f.transitions {
+		if key.src == f.current {
+			transitions = append(transitions, key.event)
+		}
+	}
+	return transitions
+}
+
 // Cannot returns true if event can not occure in the current state.
 // It is a convenience method to help code read nicely.
 func (f *FSM) Cannot(event string) bool {

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -16,6 +16,7 @@ package fsm
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -718,6 +719,24 @@ func ExampleFSM_Can() {
 	// Output:
 	// true
 	// false
+}
+
+func ExampleFSM_AvailableTransitions() {
+	fsm := NewFSM(
+		"closed",
+		Events{
+			{Name: "open", Src: []string{"closed"}, Dst: "open"},
+			{Name: "close", Src: []string{"open"}, Dst: "closed"},
+			{Name: "kick", Src: []string{"closed"}, Dst: "broken"},
+		},
+		Callbacks{},
+	)
+	// sort the results ordering is consistent for the output checker
+	transitions := fsm.AvailableTransitions()
+	sort.Strings(transitions)
+	fmt.Println(transitions)
+	// Output:
+	// [kick open]
 }
 
 func ExampleFSM_Cannot() {


### PR DESCRIPTION
- AvailableTransitions gets a list of transitions available in the
current state.   Takes out a read lock on the stateMu.
- I sorted the []string response in the test to ensure that the array items are
printed in a predictable order. 
- should resolve issue #27 (feature request for AvailableTransitions)
- O(n) was the best solution I could come up with short of creating a new data structure for this purpose.