### PR TITLE
Fix deadlock when event fired in callback

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -267,6 +267,12 @@ func (f *FSM) Cannot(event string) bool {
 // The last error should never occur in this situation and is a sign of an
 // internal bug.
 func (f *FSM) Event(event string, args ...interface{}) error {
+	// Fix for #36: https://github.com/looplab/fsm/issues/36
+	// Check is needed to avoid deadlock when event is fired from callback
+	if f.transition != nil {
+		return InTransitionError{event}
+	}
+
 	f.eventMu.Lock()
 	defer f.eventMu.Unlock()
 

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -546,6 +546,27 @@ func TestNoDeadLock(t *testing.T) {
 	fsm.Event("run")
 }
 
+func TestEventInEvent(t *testing.T) {
+	var fsm *FSM
+	fsm = NewFSM(
+		"off",
+		Events{
+			{Name: "turn-on", Src: []string{"off"}, Dst: "on"},
+			{Name: "turn-off", Src: []string{"on"}, Dst: "off"},
+		},
+		Callbacks{
+			"leave_off": func(e *Event) {
+				// Test will fail because of timeout if deadlock is happening here
+				err := fsm.Event("turn-off")
+				if err == nil {
+					t.Error("expected to get an error")
+				}
+			},
+		},
+	)
+	fsm.Event("turn-on")
+}
+
 func TestThreadSafetyRaceCondition(t *testing.T) {
 	fsm := NewFSM(
 		"start",


### PR DESCRIPTION
Fixes #36 

Changes:
 * Do check if there is a transition going on also before acquiring event lock
 * Add test case to verify no deadlock is happening when event is fired in callback

I'm not sure if that is safe to remove second check (after acquiring `stateMu` lock) so I just added one more before locks. 