### PR TITLE
fix mutex unlock error on callback panic (#49)

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -318,8 +318,8 @@ func (f *FSM) Event(event string, args ...interface{}) error {
 
 	// Perform the rest of the transition, if not asynchronous.
 	f.stateMu.RUnlock()
+	defer f.stateMu.RLock()
 	err = f.doTransition()
-	f.stateMu.RLock()
 	if err != nil {
 		return InternalError{}
 	}

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -530,6 +530,31 @@ func TestCallbackArgs(t *testing.T) {
 	fsm.Event("run", "test")
 }
 
+func TestCallbackPanic(t *testing.T) {
+	panicMsg := "unexpected panic"
+	defer func() {
+		r := recover()
+		if r == nil || r != panicMsg {
+			t.Errorf("expected panic message to be '%s', got %v", panicMsg, r)
+		}
+	}()
+	fsm := NewFSM(
+		"start",
+		Events{
+			{Name: "run", Src: []string{"start"}, Dst: "end"},
+		},
+		Callbacks{
+			"run": func(e *Event) {
+				panic(panicMsg)
+			},
+		},
+	)
+	e := fsm.Event("run")
+	if e.Error() != "error" {
+		t.Error("expected error to be 'error'")
+	}
+}
+
 func TestNoDeadLock(t *testing.T) {
 	var fsm *FSM
 	fsm = NewFSM(


### PR DESCRIPTION
This is a bugfix for #49 

The code would try to exit following a `panic` in a callback and would rightly attempt to `RUnlock` the mutex since it's on the defer stack, however, the matching `RLock` call never gets called.

The fix puts the matching `RLock` call also on the defer stack in the event that a panic occurs.