### PR TITLE
fix: visualizer did not return stable graphs

### DIFF
--- a/mermaid_visualizer_test.go
+++ b/mermaid_visualizer_test.go
@@ -42,6 +42,8 @@ func TestMermaidFlowChartOutput(t *testing.T) {
 		"closed",
 		Events{
 			{Name: "open", Src: []string{"closed"}, Dst: "open"},
+			{Name: "part-open", Src: []string{"closed"}, Dst: "intermediate"},
+			{Name: "part-open", Src: []string{"intermediate"}, Dst: "open"},
 			{Name: "close", Src: []string{"open"}, Dst: "closed"},
 			{Name: "part-close", Src: []string{"intermediate"}, Dst: "closed"},
 		},
@@ -59,7 +61,9 @@ graph LR
     id2[open]
 
     id0 --> |open| id2
+    id0 --> |part-open| id1
     id1 --> |part-close| id0
+    id1 --> |part-open| id2
     id2 --> |close| id0
 
     style id0 fill:#00AA00

--- a/visualizer.go
+++ b/visualizer.go
@@ -44,6 +44,9 @@ func getSortedTransitionKeys(transitions map[eKey]string) []eKey {
 		sortedTransitionKeys = append(sortedTransitionKeys, transition)
 	}
 	sort.Slice(sortedTransitionKeys, func(i, j int) bool {
+		if sortedTransitionKeys[i].src == sortedTransitionKeys[j].src {
+			return sortedTransitionKeys[i].event < sortedTransitionKeys[j].event
+		}
 		return sortedTransitionKeys[i].src < sortedTransitionKeys[j].src
 	})
 


### PR DESCRIPTION
Transitions were only sorted by src and not by event as well. Thus, whenever a graph had more than 1 transition from the same source, the graph output was pretty random.