### PR TITLE
Fix test error description and add cancel transaction method

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,8 @@
 
 package fsm
 
+import "context"
+
 // InvalidEventError is returned by FSM.Event() when the event cannot be called
 // in the current state.
 type InvalidEventError struct {
@@ -80,8 +82,11 @@ func (e CanceledError) Error() string {
 
 // AsyncError is returned by FSM.Event() when a callback have initiated an
 // asynchronous state transition.
+// 
+// Ctx indicates if the transition is done.
 type AsyncError struct {
 	Err error
+	Ctx context.Context
 }
 
 func (e AsyncError) Error() string {

--- a/fsm.go
+++ b/fsm.go
@@ -355,6 +355,16 @@ func (f *FSM) Transition() error {
 	return f.doTransition()
 }
 
+func (f *FSM) CancelTransition() error {
+	f.eventMu.Lock()
+	defer f.eventMu.Unlock()
+	if f.transition == nil {
+		return NotInTransitionError{}
+	}
+	f.transition = nil
+	return nil
+}
+
 // doTransition wraps transitioner.transition.
 func (f *FSM) doTransition() error {
 	return f.transitionerObj.transition(f)

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -29,6 +29,10 @@ func (t fakeTransitionerObj) transition(f *FSM) error {
 	return &InternalError{}
 }
 
+func (t fakeTransitionerObj) cancelTransition(f *FSM) error {
+	return nil
+}
+
 func TestSameState(t *testing.T) {
 	fsm := NewFSM(
 		"start",

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -53,7 +53,7 @@ func TestSetState(t *testing.T) {
 	)
 	fsm.SetState("start")
 	if fsm.Current() != "start" {
-		t.Error("expected state to be 'walking'")
+		t.Error("expected state to be 'start'")
 	}
 	err := fsm.Event("walk")
 	if err != nil {


### PR DESCRIPTION
⚠️ May breaking changes

Extended the `transitioner` interface with `cancelTransition(*FSM) error` method.