### PR TITLE
Add context to Event method, callback handlers and canceling an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ From examples/simple.go:
 package main
 
 import (
+    "context"
     "fmt"
+
     "github.com/looplab/fsm"
 )
 
@@ -39,14 +41,14 @@ func main() {
 
     fmt.Println(fsm.Current())
 
-    err := fsm.Event("open")
+    err := fsm.Event(context.Background(), "open")
     if err != nil {
         fmt.Println(err)
     }
 
     fmt.Println(fsm.Current())
 
-    err = fsm.Event("close")
+    err = fsm.Event(context.Background(), "close")
     if err != nil {
         fmt.Println(err)
     }
@@ -63,7 +65,9 @@ From examples/struct.go:
 package main
 
 import (
+    "context"
     "fmt"
+
     "github.com/looplab/fsm"
 )
 
@@ -84,7 +88,7 @@ func NewDoor(to string) *Door {
             {Name: "close", Src: []string{"open"}, Dst: "closed"},
         },
         fsm.Callbacks{
-            "enter_state": func(e *fsm.Event) { d.enterState(e) },
+            "enter_state": func(_ context.Context, e *fsm.Event) { d.enterState(e) },
         },
     )
 
@@ -98,12 +102,12 @@ func (d *Door) enterState(e *fsm.Event) {
 func main() {
     door := NewDoor("heaven")
 
-    err := door.FSM.Event("open")
+    err := door.FSM.Event(context.Background(), "open")
     if err != nil {
         fmt.Println(err)
     }
 
-    err = door.FSM.Event("close")
+    err = door.FSM.Event(context.Background(), "close")
     if err != nil {
         fmt.Println(err)
     }

--- a/event.go
+++ b/event.go
@@ -39,6 +39,9 @@ type Event struct {
 
 	// async is an internal flag set if the transition should be asynchronous
 	async bool
+
+	// cancelFunc is called in case the event is canceled.
+	cancelFunc func()
 }
 
 // Cancel can be called in before_<EVENT> or leave_<STATE> to cancel the
@@ -46,6 +49,7 @@ type Event struct {
 // overwrite e.Err if set before.
 func (e *Event) Cancel(err ...error) {
 	e.canceled = true
+	e.cancelFunc()
 
 	if len(err) > 0 {
 		e.Err = err[0]

--- a/examples/alternate.go
+++ b/examples/alternate.go
@@ -1,9 +1,12 @@
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/looplab/fsm"
 )
 
@@ -18,16 +21,16 @@ func main() {
 			{Name: "finish", Src: []string{"scanning"}, Dst: "idle"},
 		},
 		fsm.Callbacks{
-			"scan": func(e *fsm.Event) {
+			"scan": func(_ context.Context, e *fsm.Event) {
 				fmt.Println("after_scan: " + e.FSM.Current())
 			},
-			"working": func(e *fsm.Event) {
+			"working": func(_ context.Context, e *fsm.Event) {
 				fmt.Println("working: " + e.FSM.Current())
 			},
-			"situation": func(e *fsm.Event) {
+			"situation": func(_ context.Context, e *fsm.Event) {
 				fmt.Println("situation: " + e.FSM.Current())
 			},
-			"finish": func(e *fsm.Event) {
+			"finish": func(_ context.Context, e *fsm.Event) {
 				fmt.Println("finish: " + e.FSM.Current())
 			},
 		},
@@ -35,28 +38,28 @@ func main() {
 
 	fmt.Println(fsm.Current())
 
-	err := fsm.Event("scan")
+	err := fsm.Event(context.Background(), "scan")
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	fmt.Println("1:" + fsm.Current())
 
-	err = fsm.Event("working")
+	err = fsm.Event(context.Background(), "working")
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	fmt.Println("2:" + fsm.Current())
 
-	err = fsm.Event("situation")
+	err = fsm.Event(context.Background(), "situation")
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	fmt.Println("3:" + fsm.Current())
 
-	err = fsm.Event("finish")
+	err = fsm.Event(context.Background(), "finish")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/data.go
+++ b/examples/data.go
@@ -1,8 +1,10 @@
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/looplab/fsm"
@@ -16,11 +18,11 @@ func main() {
 			{Name: "consume", Src: []string{"idle"}, Dst: "idle"},
 		},
 		fsm.Callbacks{
-			"produce": func(e *fsm.Event) {
+			"produce": func(_ context.Context, e *fsm.Event) {
 				e.FSM.SetMetadata("message", "hii")
 				fmt.Println("produced data")
 			},
-			"consume": func(e *fsm.Event) {
+			"consume": func(_ context.Context, e *fsm.Event) {
 				message, ok := e.FSM.Metadata("message")
 				if ok {
 					fmt.Println("message = " + message.(string))
@@ -32,14 +34,14 @@ func main() {
 
 	fmt.Println(fsm.Current())
 
-	err := fsm.Event("produce")
+	err := fsm.Event(context.Background(), "produce")
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	fmt.Println(fsm.Current())
 
-	err = fsm.Event("consume")
+	err = fsm.Event(context.Background(), "consume")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -1,9 +1,12 @@
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/looplab/fsm"
 )
 
@@ -19,14 +22,14 @@ func main() {
 
 	fmt.Println(fsm.Current())
 
-	err := fsm.Event("open")
+	err := fsm.Event(context.Background(), "open")
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	fmt.Println(fsm.Current())
 
-	err = fsm.Event("close")
+	err = fsm.Event(context.Background(), "close")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/struct.go
+++ b/examples/struct.go
@@ -1,9 +1,12 @@
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/looplab/fsm"
 )
 
@@ -24,7 +27,7 @@ func NewDoor(to string) *Door {
 			{Name: "close", Src: []string{"open"}, Dst: "closed"},
 		},
 		fsm.Callbacks{
-			"enter_state": func(e *fsm.Event) { d.enterState(e) },
+			"enter_state": func(_ context.Context, e *fsm.Event) { d.enterState(e) },
 		},
 	)
 
@@ -38,12 +41,12 @@ func (d *Door) enterState(e *fsm.Event) {
 func main() {
 	door := NewDoor("heaven")
 
-	err := door.FSM.Event("open")
+	err := door.FSM.Event(context.Background(), "open")
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	err = door.FSM.Event("close")
+	err = door.FSM.Event(context.Background(), "close")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -38,7 +38,7 @@ func TestSameState(t *testing.T) {
 		},
 		Callbacks{},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -56,7 +56,7 @@ func TestSetState(t *testing.T) {
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'walking'")
 	}
-	err := fsm.Event("walk")
+	err := fsm.Event(context.Background(), "walk")
 	if err != nil {
 		t.Error("transition is expected no error")
 	}
@@ -71,7 +71,7 @@ func TestBadTransition(t *testing.T) {
 		Callbacks{},
 	)
 	fsm.transitionerObj = new(fakeTransitionerObj)
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if err == nil {
 		t.Error("bad transition should give an error")
 	}
@@ -86,7 +86,7 @@ func TestInappropriateEvent(t *testing.T) {
 		},
 		Callbacks{},
 	)
-	err := fsm.Event("close")
+	err := fsm.Event(context.Background(), "close")
 	if e, ok := err.(InvalidEventError); !ok && e.Event != "close" && e.State != "closed" {
 		t.Error("expected 'InvalidEventError' with correct state and event")
 	}
@@ -101,7 +101,7 @@ func TestInvalidEvent(t *testing.T) {
 		},
 		Callbacks{},
 	)
-	err := fsm.Event("lock")
+	err := fsm.Event(context.Background(), "lock")
 	if e, ok := err.(UnknownEventError); !ok && e.Event != "close" {
 		t.Error("expected 'UnknownEventError' with correct event")
 	}
@@ -118,32 +118,32 @@ func TestMultipleSources(t *testing.T) {
 		Callbacks{},
 	)
 
-	err := fsm.Event("first")
+	err := fsm.Event(context.Background(), "first")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
 	if fsm.Current() != "two" {
 		t.Error("expected state to be 'two'")
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
 	if fsm.Current() != "one" {
 		t.Error("expected state to be 'one'")
 	}
-	err = fsm.Event("first")
+	err = fsm.Event(context.Background(), "first")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
-	err = fsm.Event("second")
+	err = fsm.Event(context.Background(), "second")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
 	if fsm.Current() != "three" {
 		t.Error("expected state to be 'three'")
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -165,18 +165,18 @@ func TestMultipleEvents(t *testing.T) {
 		Callbacks{},
 	)
 
-	err := fsm.Event("first")
+	err := fsm.Event(context.Background(), "first")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
 	if fsm.Current() != "reset_one" {
 		t.Error("expected state to be 'reset_one'")
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -184,18 +184,18 @@ func TestMultipleEvents(t *testing.T) {
 		t.Error("expected state to be 'start'")
 	}
 
-	err = fsm.Event("second")
+	err = fsm.Event(context.Background(), "second")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
 	if fsm.Current() != "reset_two" {
 		t.Error("expected state to be 'reset_two'")
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -216,22 +216,22 @@ func TestGenericCallbacks(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"before_event": func(e *Event) {
+			"before_event": func(_ context.Context, e *Event) {
 				beforeEvent = true
 			},
-			"leave_state": func(e *Event) {
+			"leave_state": func(_ context.Context, e *Event) {
 				leaveState = true
 			},
-			"enter_state": func(e *Event) {
+			"enter_state": func(_ context.Context, e *Event) {
 				enterState = true
 			},
-			"after_event": func(e *Event) {
+			"after_event": func(_ context.Context, e *Event) {
 				afterEvent = true
 			},
 		},
 	)
 
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -252,22 +252,22 @@ func TestSpecificCallbacks(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"before_run": func(e *Event) {
+			"before_run": func(_ context.Context, e *Event) {
 				beforeEvent = true
 			},
-			"leave_start": func(e *Event) {
+			"leave_start": func(_ context.Context, e *Event) {
 				leaveState = true
 			},
-			"enter_end": func(e *Event) {
+			"enter_end": func(_ context.Context, e *Event) {
 				enterState = true
 			},
-			"after_run": func(e *Event) {
+			"after_run": func(_ context.Context, e *Event) {
 				afterEvent = true
 			},
 		},
 	)
 
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -286,16 +286,16 @@ func TestSpecificCallbacksShortform(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"end": func(e *Event) {
+			"end": func(_ context.Context, e *Event) {
 				enterState = true
 			},
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 				afterEvent = true
 			},
 		},
 	)
 
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -313,13 +313,13 @@ func TestBeforeEventWithoutTransition(t *testing.T) {
 			{Name: "dontrun", Src: []string{"start"}, Dst: "start"},
 		},
 		Callbacks{
-			"before_event": func(e *Event) {
+			"before_event": func(_ context.Context, e *Event) {
 				beforeEvent = true
 			},
 		},
 	)
 
-	err := fsm.Event("dontrun")
+	err := fsm.Event(context.Background(), "dontrun")
 	if e, ok := err.(NoTransitionError); !ok && e.Err != nil {
 		t.Error("expected 'NoTransitionError' without custom error")
 	}
@@ -339,12 +339,12 @@ func TestCancelBeforeGenericEvent(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"before_event": func(e *Event) {
+			"before_event": func(_ context.Context, e *Event) {
 				e.Cancel()
 			},
 		},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -357,12 +357,12 @@ func TestCancelBeforeSpecificEvent(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"before_run": func(e *Event) {
+			"before_run": func(_ context.Context, e *Event) {
 				e.Cancel()
 			},
 		},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -375,12 +375,12 @@ func TestCancelLeaveGenericState(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"leave_state": func(e *Event) {
+			"leave_state": func(_ context.Context, e *Event) {
 				e.Cancel()
 			},
 		},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -393,12 +393,12 @@ func TestCancelLeaveSpecificState(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"leave_start": func(e *Event) {
+			"leave_start": func(_ context.Context, e *Event) {
 				e.Cancel()
 			},
 		},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -411,12 +411,12 @@ func TestCancelWithError(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"before_event": func(e *Event) {
+			"before_event": func(_ context.Context, e *Event) {
 				e.Cancel(fmt.Errorf("error"))
 			},
 		},
 	)
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if _, ok := err.(CanceledError); !ok {
 		t.Error("expected only 'CanceledError'")
 	}
@@ -437,12 +437,12 @@ func TestAsyncTransitionGenericState(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"leave_state": func(e *Event) {
+			"leave_state": func(_ context.Context, e *Event) {
 				e.Async()
 			},
 		},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -462,12 +462,12 @@ func TestAsyncTransitionSpecificState(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"leave_start": func(e *Event) {
+			"leave_start": func(_ context.Context, e *Event) {
 				e.Async()
 			},
 		},
 	)
-	_ = fsm.Event("run")
+	_ = fsm.Event(context.Background(), "run")
 	if fsm.Current() != "start" {
 		t.Error("expected state to be 'start'")
 	}
@@ -488,13 +488,13 @@ func TestAsyncTransitionInProgress(t *testing.T) {
 			{Name: "reset", Src: []string{"end"}, Dst: "start"},
 		},
 		Callbacks{
-			"leave_start": func(e *Event) {
+			"leave_start": func(_ context.Context, e *Event) {
 				e.Async()
 			},
 		},
 	)
-	_ = fsm.Event("run")
-	err := fsm.Event("reset")
+	_ = fsm.Event(context.Background(), "run")
+	err := fsm.Event(context.Background(), "reset")
 	if e, ok := err.(InTransitionError); !ok && e.Event != "reset" {
 		t.Error("expected 'InTransitionError' with correct state")
 	}
@@ -502,7 +502,7 @@ func TestAsyncTransitionInProgress(t *testing.T) {
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
-	err = fsm.Event("reset")
+	err = fsm.Event(context.Background(), "reset")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -533,11 +533,11 @@ func TestCallbackNoError(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 			},
 		},
 	)
-	e := fsm.Event("run")
+	e := fsm.Event(context.Background(), "run")
 	if e != nil {
 		t.Error("expected no error")
 	}
@@ -550,12 +550,12 @@ func TestCallbackError(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 				e.Err = fmt.Errorf("error")
 			},
 		},
 	)
-	e := fsm.Event("run")
+	e := fsm.Event(context.Background(), "run")
 	if e.Error() != "error" {
 		t.Error("expected error to be 'error'")
 	}
@@ -568,7 +568,7 @@ func TestCallbackArgs(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 				if len(e.Args) != 1 {
 					t.Error("too few arguments")
 				}
@@ -582,7 +582,7 @@ func TestCallbackArgs(t *testing.T) {
 			},
 		},
 	)
-	err := fsm.Event("run", "test")
+	err := fsm.Event(context.Background(), "run", "test")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -602,12 +602,12 @@ func TestCallbackPanic(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 				panic(panicMsg)
 			},
 		},
 	)
-	e := fsm.Event("run")
+	e := fsm.Event(context.Background(), "run")
 	if e.Error() != "error" {
 		t.Error("expected error to be 'error'")
 	}
@@ -621,12 +621,12 @@ func TestNoDeadLock(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 				fsm.Current() // Should not result in a panic / deadlock
 			},
 		},
 	)
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -639,7 +639,7 @@ func TestThreadSafetyRaceCondition(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"run": func(e *Event) {
+			"run": func(_ context.Context, e *Event) {
 			},
 		},
 	)
@@ -649,7 +649,7 @@ func TestThreadSafetyRaceCondition(t *testing.T) {
 		defer wg.Done()
 		_ = fsm.Current()
 	}()
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
@@ -666,7 +666,7 @@ func TestDoubleTransition(t *testing.T) {
 			{Name: "run", Src: []string{"start"}, Dst: "end"},
 		},
 		Callbacks{
-			"before_run": func(e *Event) {
+			"before_run": func(_ context.Context, e *Event) {
 				wg.Done()
 				// Imagine a concurrent event coming in of the same type while
 				// the data access mutex is unlocked because the current transition
@@ -677,7 +677,7 @@ func TestDoubleTransition(t *testing.T) {
 					// calls to Event(...). It will then fail as an inappropriate transition as we
 					// have changed state.
 					go func() {
-						if err := fsm.Event("run", "second run"); err != nil {
+						if err := fsm.Event(context.Background(), "run", "second run"); err != nil {
 							fmt.Println(err)
 							wg.Done() // It should fail, and then we unfreeze the test.
 						}
@@ -689,7 +689,7 @@ func TestDoubleTransition(t *testing.T) {
 			},
 		},
 	)
-	if err := fsm.Event("run"); err != nil {
+	if err := fsm.Event(context.Background(), "run"); err != nil {
 		fmt.Println(err)
 	}
 	wg.Wait()
@@ -740,7 +740,7 @@ func TestNoTransition(t *testing.T) {
 		},
 		Callbacks{},
 	)
-	err := fsm.Event("run")
+	err := fsm.Event(context.Background(), "run")
 	if _, ok := err.(NoTransitionError); !ok {
 		t.Error("expected 'NoTransitionError'")
 	}
@@ -757,34 +757,34 @@ func ExampleNewFSM() {
 			{Name: "clear", Src: []string{"yellow"}, Dst: "green"},
 		},
 		Callbacks{
-			"before_warn": func(e *Event) {
+			"before_warn": func(_ context.Context, e *Event) {
 				fmt.Println("before_warn")
 			},
-			"before_event": func(e *Event) {
+			"before_event": func(_ context.Context, e *Event) {
 				fmt.Println("before_event")
 			},
-			"leave_green": func(e *Event) {
+			"leave_green": func(_ context.Context, e *Event) {
 				fmt.Println("leave_green")
 			},
-			"leave_state": func(e *Event) {
+			"leave_state": func(_ context.Context, e *Event) {
 				fmt.Println("leave_state")
 			},
-			"enter_yellow": func(e *Event) {
+			"enter_yellow": func(_ context.Context, e *Event) {
 				fmt.Println("enter_yellow")
 			},
-			"enter_state": func(e *Event) {
+			"enter_state": func(_ context.Context, e *Event) {
 				fmt.Println("enter_state")
 			},
-			"after_warn": func(e *Event) {
+			"after_warn": func(_ context.Context, e *Event) {
 				fmt.Println("after_warn")
 			},
-			"after_event": func(e *Event) {
+			"after_event": func(_ context.Context, e *Event) {
 				fmt.Println("after_event")
 			},
 		},
 	)
 	fmt.Println(fsm.Current())
-	err := fsm.Event("warn")
+	err := fsm.Event(context.Background(), "warn")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -891,12 +891,12 @@ func ExampleFSM_Event() {
 		Callbacks{},
 	)
 	fmt.Println(fsm.Current())
-	err := fsm.Event("open")
+	err := fsm.Event(context.Background(), "open")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Println(fsm.Current())
-	err = fsm.Event("close")
+	err = fsm.Event(context.Background(), "close")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -915,12 +915,12 @@ func ExampleFSM_Transition() {
 			{Name: "close", Src: []string{"open"}, Dst: "closed"},
 		},
 		Callbacks{
-			"leave_closed": func(e *Event) {
+			"leave_closed": func(_ context.Context, e *Event) {
 				e.Async()
 			},
 		},
 	)
-	err := fsm.Event("open")
+	err := fsm.Event(context.Background(), "open")
 	if e, ok := err.(AsyncError); !ok && e.Err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
This PR adds a context to the main `Event` method. It's also in response to https://github.com/looplab/fsm/pull/37#issuecomment-992477957. Finally, it's the first step towards implementing #43 and #38.

Adding the context is a breaking change and while the library isn't at v1.0.0 yet it's still an inconvenience. I distinctly didn't add a `CallbacksContext` field because of the following reasons:
- while an inconvenience, it's easy to add the context to all callback functions – even the way I did in the test suite using `_ context.Context`
- it'd make the internal logic fragile
- it's now best practice to have a context available, especially given the fact that the library supports asynchronous transitions and be able to cancel work that isn't needed anymore

Of course, if the maintainer(s)/contributors/the community at large wants this then it's still totally possible.

To see the whole thing in action, potential users can use the full implementation: https://github.com/alfaview/fsm/pull/1 (this PR only contains the first part).