### PR TITLE
Highlight current state in Graphviz visualizer

### DIFF
--- a/graphviz_visualizer.go
+++ b/graphviz_visualizer.go
@@ -14,8 +14,8 @@ func Visualize(fsm *FSM) string {
 	sortedStateKeys, _ := getSortedStates(fsm.transitions)
 
 	writeHeaderLine(&buf)
-	writeTransitions(&buf, fsm.current, sortedEKeys, fsm.transitions)
-	writeStates(&buf, sortedStateKeys)
+	writeTransitions(&buf, sortedEKeys, fsm.transitions)
+	writeStates(&buf, fsm.current, sortedStateKeys)
 	writeFooter(&buf)
 
 	return buf.String()
@@ -26,29 +26,23 @@ func writeHeaderLine(buf *bytes.Buffer) {
 	buf.WriteString("\n")
 }
 
-func writeTransitions(buf *bytes.Buffer, current string, sortedEKeys []eKey, transitions map[eKey]string) {
-	// make sure the current state is at top
+func writeTransitions(buf *bytes.Buffer, sortedEKeys []eKey, transitions map[eKey]string) {
 	for _, k := range sortedEKeys {
-		if k.src == current {
-			v := transitions[k]
-			buf.WriteString(fmt.Sprintf(`    "%s" -> "%s" [ label = "%s" ];`, k.src, v, k.event))
-			buf.WriteString("\n")
-		}
-	}
-	for _, k := range sortedEKeys {
-		if k.src != current {
-			v := transitions[k]
-			buf.WriteString(fmt.Sprintf(`    "%s" -> "%s" [ label = "%s" ];`, k.src, v, k.event))
-			buf.WriteString("\n")
-		}
+		v := transitions[k]
+		buf.WriteString(fmt.Sprintf(`    "%s" -> "%s" [ label = "%s" ];`, k.src, v, k.event))
+		buf.WriteString("\n")
 	}
 
 	buf.WriteString("\n")
 }
 
-func writeStates(buf *bytes.Buffer, sortedStateKeys []string) {
+func writeStates(buf *bytes.Buffer, current string, sortedStateKeys []string) {
 	for _, k := range sortedStateKeys {
-		buf.WriteString(fmt.Sprintf(`    "%s";`, k))
+		if k == current {
+			buf.WriteString(fmt.Sprintf(`    "%s" [color = "red"];`, k))
+		} else {
+			buf.WriteString(fmt.Sprintf(`    "%s";`, k))
+		}
 		buf.WriteString("\n")
 	}
 }

--- a/graphviz_visualizer_test.go
+++ b/graphviz_visualizer_test.go
@@ -24,7 +24,7 @@ digraph fsm {
     "intermediate" -> "closed" [ label = "part-close" ];
     "open" -> "closed" [ label = "close" ];
 
-    "closed";
+    "closed" [color = "red"];
     "intermediate";
     "open";
 }`


### PR DESCRIPTION
This PR changes the current Graphviz visualizer in the following way:
- Keep the drawing order when current state changes to have a stable state diagram output.
Instead, the current state is highlighted.