### PR TITLE
Allow transitions in callbacks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,10 @@
 
 package fsm
 
+import (
+	"context"
+)
+
 // InvalidEventError is returned by FSM.Event() when the event cannot be called
 // in the current state.
 type InvalidEventError struct {
@@ -82,6 +86,9 @@ func (e CanceledError) Error() string {
 // asynchronous state transition.
 type AsyncError struct {
 	Err error
+
+	Ctx              context.Context
+	CancelTransition func()
 }
 
 func (e AsyncError) Error() string {

--- a/examples/cancel_async_transition.go
+++ b/examples/cancel_async_transition.go
@@ -1,0 +1,54 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/looplab/fsm"
+)
+
+func main() {
+	f := fsm.NewFSM(
+		"start",
+		fsm.Events{
+			{Name: "run", Src: []string{"start"}, Dst: "end"},
+		},
+		fsm.Callbacks{
+			"leave_start": func(_ context.Context, e *fsm.Event) {
+				e.Async()
+			},
+		},
+	)
+
+	err := f.Event(context.Background(), "run")
+	asyncError, ok := err.(fsm.AsyncError)
+	if !ok {
+		panic(fmt.Sprintf("expected error to be 'AsyncError', got %v", err))
+	}
+	var asyncStateTransitionWasCanceled bool
+	go func() {
+		<-asyncError.Ctx.Done()
+		asyncStateTransitionWasCanceled = true
+		if asyncError.Ctx.Err() != context.Canceled {
+			panic(fmt.Sprintf("Expected error to be '%v' but was '%v'", context.Canceled, asyncError.Ctx.Err()))
+		}
+	}()
+	asyncError.CancelTransition()
+	time.Sleep(20 * time.Millisecond)
+
+	if err = f.Transition(); err != nil {
+		panic(fmt.Sprintf("Error encountered when transitioning: %v", err))
+	}
+	if !asyncStateTransitionWasCanceled {
+		panic("expected async state transition cancelation to have propagated")
+	}
+	if f.Current() != "start" {
+		panic("expected state to be 'start'")
+	}
+
+	fmt.Println("Successfully ran state machine.")
+}

--- a/examples/transition_callbacks.go
+++ b/examples/transition_callbacks.go
@@ -1,0 +1,54 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/looplab/fsm"
+)
+
+func main() {
+	var afterFinishCalled bool
+	fsm := fsm.NewFSM(
+		"start",
+		fsm.Events{
+			{Name: "run", Src: []string{"start"}, Dst: "end"},
+			{Name: "finish", Src: []string{"end"}, Dst: "finished"},
+			{Name: "reset", Src: []string{"end", "finished"}, Dst: "start"},
+		},
+		fsm.Callbacks{
+			"enter_end": func(ctx context.Context, e *fsm.Event) {
+				if err := e.FSM.Event(ctx, "finish"); err != nil {
+					fmt.Println(err)
+				}
+			},
+			"after_finish": func(ctx context.Context, e *fsm.Event) {
+				afterFinishCalled = true
+				if e.Src != "end" {
+					panic(fmt.Sprintf("source should have been 'end' but was '%s'", e.Src))
+				}
+				if err := e.FSM.Event(ctx, "reset"); err != nil {
+					fmt.Println(err)
+				}
+			},
+		},
+	)
+
+	if err := fsm.Event(context.Background(), "run"); err != nil {
+		panic(fmt.Sprintf("Error encountered when triggering the run event: %v", err))
+	}
+
+	if !afterFinishCalled {
+		panic(fmt.Sprintf("After finish callback should have run, current state: '%s'", fsm.Current()))
+	}
+
+	currentState := fsm.Current()
+	if currentState != "start" {
+		panic(fmt.Sprintf("expected state to be 'start', was '%s'", currentState))
+	}
+
+	fmt.Println("Successfully ran state machine.")
+}

--- a/uncancel_context.go
+++ b/uncancel_context.go
@@ -1,0 +1,21 @@
+package fsm
+
+import (
+	"context"
+	"time"
+)
+
+type uncancel struct {
+	context.Context
+}
+
+func (*uncancel) Deadline() (deadline time.Time, ok bool) { return }
+func (*uncancel) Done() <-chan struct{}                   { return nil }
+func (*uncancel) Err() error                              { return nil }
+
+// uncancelContext returns a context which ignores the cancellation of the parent and only keeps the values.
+// Also returns a new cancel function.
+// This is useful to keep a background task running while the initial request is finished.
+func uncancelContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithCancel(&uncancel{ctx})
+}

--- a/uncancel_context_test.go
+++ b/uncancel_context_test.go
@@ -1,0 +1,91 @@
+package fsm
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUncancel(t *testing.T) {
+	t.Run("create a new context", func(t *testing.T) {
+		t.Run("and cancel it", func(t *testing.T) {
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, "key1", "value1")
+			ctx, cancelFunc := context.WithCancel(ctx)
+			cancelFunc()
+
+			if ctx.Err() != context.Canceled {
+				t.Errorf("expected context error 'context canceled', got %v", ctx.Err())
+			}
+			select {
+			case <-ctx.Done():
+			default:
+				t.Error("expected context to be done but it wasn't")
+			}
+
+			t.Run("and uncancel it", func(t *testing.T) {
+				ctx, newCancelFunc := uncancelContext(ctx)
+				if ctx.Err() != nil {
+					t.Errorf("expected context error to be nil, got %v", ctx.Err())
+				}
+				select {
+				case <-ctx.Done():
+					t.Fail()
+				default:
+				}
+
+				t.Run("now it should still contain the values", func(t *testing.T) {
+					if ctx.Value("key1") != "value1" {
+						t.Errorf("expected context value of key 'key1' to be 'value1', got %v", ctx.Value("key1"))
+					}
+				})
+				t.Run("and cancel the child", func(t *testing.T) {
+					newCancelFunc()
+					if ctx.Err() != context.Canceled {
+						t.Errorf("expected context error 'context canceled', got %v", ctx.Err())
+					}
+					select {
+					case <-ctx.Done():
+					default:
+						t.Error("expected context to be done but it wasn't")
+					}
+				})
+			})
+		})
+		t.Run("and uncancel it", func(t *testing.T) {
+			ctx := context.Background()
+			parent := ctx
+			ctx, newCancelFunc := uncancelContext(ctx)
+			if ctx.Err() != nil {
+				t.Errorf("expected context error to be nil, got %v", ctx.Err())
+			}
+			select {
+			case <-ctx.Done():
+				t.Fail()
+			default:
+			}
+
+			t.Run("and cancel the child", func(t *testing.T) {
+				newCancelFunc()
+				if ctx.Err() != context.Canceled {
+					t.Errorf("expected context error 'context canceled', got %v", ctx.Err())
+				}
+				select {
+				case <-ctx.Done():
+				default:
+					t.Error("expected context to be done but it wasn't")
+				}
+
+				t.Run("and ensure the parent is not affected", func(t *testing.T) {
+					if parent.Err() != nil {
+						t.Errorf("expected parent context error to be nil, got %v", ctx.Err())
+					}
+					select {
+					case <-parent.Done():
+						t.Fail()
+					default:
+					}
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
This allows state transitions to happen in enter state and after event callbacks by adding the possibility of "starting" a state machine and have it execute multiple state transitions in succession, given that no errors occur.

The equivalent code without this change:
```go
var errTransition error

for errTransition == nil {
	transitions := request.FSM.AvailableTransitions()
	if len(transitions) == 0 {
		break
	}
	if len(transitions) > 1 {
		errTransition = errors.New("only 1 transition should be available")
	}
	errTransition = request.FSM.Event(transitions[0])
}

if errTransition != nil {
	fmt.Println(errTransition)
}
```

Arguably, that’s bad because of several reasons:
1. The state machine is used like a puppet.
2. The state transitions that make up the "happy path" are encoded
   outside the state machine.
3. The code really isn’t good.
4. There’s no way to intervene or make different decisions on which
   state to transition to next (reinforces bullet point 2).
5. There’s no way to add proper error handling.

It is possible to fix a certain number of those problems but not all
of them, especially 2 and 4 but also 1.

The added test is green and uses both an enter state and an after event
callback. No other test case was touched in any way (besides enhancing the
context one that was added in the previous commit).

The relevant test is here: https://github.com/alfaview/fsm/blob/94fb353ef273319b14928aa3a04ab4e01a58d6da/fsm_test.go#L735-L774

This fixes #36. It also fixes #38. And it fixes #43. Finally, it fixes #61.