### PR TITLE
Add a decorator for callback error handling

### DIFF
--- a/event_decorators.go
+++ b/event_decorators.go
@@ -1,0 +1,34 @@
+package fsm
+
+import "context"
+
+// CallbackWithErr is an FSM callback function that can return an error. The primary use case for this is for
+// CallbackWithErr to be used as an argument to DecorateCallbackWithErrorHandling.
+type CallbackWithErr func(ctx context.Context, event *Event) error
+
+// DecorateCallbackWithErrorHandling is a decorator for FSM callbacks that will catch any errors returned by the
+// callback and set them on the event's Err field. This is useful for standardizing the way any error encountered
+// during an FSM callback are handled.
+// Example usage:
+//
+//	fsm := NewFSM(
+//		"start",
+//		Events{
+//			{Name: "run", Src: []string{"start"}, Dst: "end"},
+//		},
+//		Callbacks{
+//			"before_event": DecorateCallbackWithErrorHandling(
+//				func(_ context.Context, e *Event) error {
+//					return errors.New("testing error handling decorator")
+//				},
+//			),
+//		},
+//	)
+func DecorateCallbackWithErrorHandling(callback CallbackWithErr) Callback {
+	return func(ctx context.Context, event *Event) {
+		err := callback(ctx, event)
+		if err != nil {
+			event.Err = err
+		}
+	}
+}

--- a/event_decorators_test.go
+++ b/event_decorators_test.go
@@ -1,0 +1,33 @@
+package fsm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDecorateCallbackWithErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	fsm := NewFSM(
+		"start",
+		Events{
+			{Name: "run", Src: []string{"start"}, Dst: "end"},
+		},
+		Callbacks{
+			"before_event": DecorateCallbackWithErrorHandling(
+				func(_ context.Context, e *Event) error {
+					return errors.New("testing error handling decorator")
+				},
+			),
+		},
+	)
+
+	err := fsm.Event(context.Background(), "run")
+	if err == nil {
+		t.Error("expected error to be returned from event")
+	}
+	if err.Error() != "testing error handling decorator" {
+		t.Errorf("expected error to be 'testing error handling decorator', got '%s'", err.Error())
+	}
+}


### PR DESCRIPTION
With the `DecorateCallbackWithErrorHandling` decorator, error handling will become easier for callbacks. This has been a pain-point for FSM users as they go with one of these options:
1. Not handle errors at all: This is because assigning the error to Event.Err is a non-idiomatic Go pattern.
2. Write `Event.Err = err` for each error case
3. Write their own decorator

Using this pattern, users can continue to write idiomatic Go code.