### PR TITLE
Deadlock calling Event in after-event callback when current state == dst

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -333,6 +333,8 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 	}
 
 	if f.current == dst {
+		f.eventMu.Unlock()
+		unlocked = true
 		f.afterEventCallbacks(ctx, e)
 		return NoTransitionError{e.Err}
 	}

--- a/fsm.go
+++ b/fsm.go
@@ -333,6 +333,8 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 	}
 
 	if f.current == dst {
+		f.stateMu.RUnlock()
+		defer f.stateMu.RLock()
 		f.eventMu.Unlock()
 		unlocked = true
 		f.afterEventCallbacks(ctx, e)

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -825,6 +825,31 @@ func TestNoTransition(t *testing.T) {
 	}
 }
 
+func TestNoTransitionAfterEventCallbackTransition(t *testing.T) {
+	var fsm *FSM
+	fsm = NewFSM(
+		"start",
+		Events{
+			{Name: "run", Src: []string{"start"}, Dst: "start"},
+			{Name: "finish", Src: []string{"start"}, Dst: "finished"},
+		},
+		Callbacks{
+			"after_event": func(_ context.Context, e *Event) {
+				fsm.Event(context.Background(), "finish")
+			},
+		},
+	)
+	err := fsm.Event(context.Background(), "run")
+	if _, ok := err.(NoTransitionError); !ok {
+		t.Error("expected 'NoTransitionError'")
+	}
+
+	currentState := fsm.Current()
+	if currentState != "finished" {
+		t.Errorf("expected state to be 'finished', was '%s'", currentState)
+	}
+}
+
 func ExampleNewFSM() {
 	fsm := NewFSM(
 		"green",


### PR DESCRIPTION
Fix for https://github.com/looplab/fsm/issues/102
Deadlock happens in case when new transition is initiated in after-event callback for dst == src