### PR TITLE
Fixed data race between Can() and Event()

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -228,6 +228,8 @@ func (f *FSM) SetState(state string) {
 
 // Can returns true if event can occur in the current state.
 func (f *FSM) Can(event string) bool {
+	f.eventMu.Lock()
+	defer f.eventMu.Unlock()
 	f.stateMu.RLock()
 	defer f.stateMu.RUnlock()
 	_, ok := f.transitions[eKey{event, f.current}]


### PR DESCRIPTION
Fixes data race between Can() and Event() https://github.com/looplab/fsm/issues/105

Test:  `go test -v -race -run TestEventAndCanInGoroutines`