### PR TITLE
feat(errors): implement error wrapping

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -69,6 +69,10 @@ func (e NoTransitionError) Error() string {
 	return "no transition"
 }
 
+func (e NoTransitionError) Unwrap() error {
+	return e.Err
+}
+
 // CanceledError is returned by FSM.Event() when a callback have canceled a
 // transition.
 type CanceledError struct {
@@ -80,6 +84,10 @@ func (e CanceledError) Error() string {
 		return "transition canceled with error: " + e.Err.Error()
 	}
 	return "transition canceled"
+}
+
+func (e CanceledError) Unwrap() error {
+	return e.Err
 }
 
 // AsyncError is returned by FSM.Event() when a callback have initiated an
@@ -96,6 +104,10 @@ func (e AsyncError) Error() string {
 		return "async started with error: " + e.Err.Error()
 	}
 	return "async started"
+}
+
+func (e AsyncError) Unwrap() error {
+	return e.Err
 }
 
 // InternalError is returned by FSM.Event() and should never occur. It is a

--- a/errors_test.go
+++ b/errors_test.go
@@ -60,6 +60,12 @@ func TestNoTransitionError(t *testing.T) {
 	if e.Error() != "no transition with error: "+e.Err.Error() {
 		t.Error("NoTransitionError string mismatch")
 	}
+	if e.Unwrap() == nil {
+		t.Error("CanceledError Unwrap() should not be nil")
+	}
+	if !errors.Is(e, e.Err) {
+		t.Error("CanceledError should be equal to its error")
+	}
 }
 
 func TestCanceledError(t *testing.T) {
@@ -71,6 +77,12 @@ func TestCanceledError(t *testing.T) {
 	if e.Error() != "transition canceled with error: "+e.Err.Error() {
 		t.Error("CanceledError string mismatch")
 	}
+	if e.Unwrap() == nil {
+		t.Error("CanceledError Unwrap() should not be nil")
+	}
+	if !errors.Is(e, e.Err) {
+		t.Error("CanceledError should be equal to its error")
+	}
 }
 
 func TestAsyncError(t *testing.T) {
@@ -81,6 +93,12 @@ func TestAsyncError(t *testing.T) {
 	e.Err = errors.New("async")
 	if e.Error() != "async started with error: "+e.Err.Error() {
 		t.Error("AsyncError string mismatch")
+	}
+	if e.Unwrap() == nil {
+		t.Error("AsyncError Unwrap() should not be nil")
+	}
+	if !errors.Is(e, e.Err) {
+		t.Error("AsyncError should be equal to its error")
 	}
 }
 


### PR DESCRIPTION
addresses https://github.com/looplab/fsm/issues/72

-----

Before this commit, if an event transition is canceled as part of callbacks, then the resulting error on the `Event()` call will _not_ be able to be examined with `errors.Is`

After this commit, if an event transition is canceled as part of callbacks, then the resulting error on the `Event()` call _can_ be examined with `errors.Is`