### PR TITLE
feat(callbacks): add before_enter_state_ callback

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -109,13 +109,17 @@ type Callbacks map[string]Callback
 //
 // 4. leave_state - called before leaving all states
 //
-// 5. enter_<NEW_STATE> - called after entering <NEW_STATE>
+// 5. before_enter_<NEW_STATE> - called before entering <NEW_STATE>
 //
-// 6. enter_state - called after entering all states
+// 6. before_enter_state - called before entering all states
 //
-// 7. after_<EVENT> - called after event named <EVENT>
+// 7. enter_<NEW_STATE> - called after entering <NEW_STATE>
 //
-// 8. after_event - called after all events
+// 8. enter_state - called after entering all states
+//
+// 9. after_<EVENT> - called after event named <EVENT>
+//
+// 10. after_event - called after all events
 //
 // There are also two short form versions for the most commonly used callbacks.
 // They are simply the name of the event or state:
@@ -155,6 +159,14 @@ func NewFSM(initial string, events []EventDesc, callbacks map[string]Callback) *
 		var callbackType int
 
 		switch {
+		case strings.HasPrefix(name, "before_enter_"):
+			target = strings.TrimPrefix(name, "before_enter_")
+			if target == "state" {
+				target = ""
+				callbackType = callbackBeforeState
+			} else if _, ok := allStates[target]; ok {
+				callbackType = callbackBeforeState
+			}
 		case strings.HasPrefix(name, "before_"):
 			target = strings.TrimPrefix(name, "before_")
 			if target == "event" {
@@ -353,6 +365,13 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 				return
 			}
 
+			if err := f.beforeStateCallbacks(ctx, e); err != nil {
+				if e.Err == nil {
+					e.Err = err
+				}
+				return
+			}
+
 			f.stateMu.Lock()
 			f.current = dst
 			f.transition = nil // treat the state transition as done
@@ -447,6 +466,24 @@ func (f *FSM) beforeEventCallbacks(ctx context.Context, e *Event) error {
 	return nil
 }
 
+// beforeStateCallbacks calls the before_enter_ callbacks, first the named then the
+// general version.
+func (f *FSM) beforeStateCallbacks(ctx context.Context, e *Event) error {
+	if fn, ok := f.callbacks[cKey{e.Dst, callbackBeforeState}]; ok {
+		fn(ctx, e)
+		if e.canceled {
+			return CanceledError{e.Err}
+		}
+	}
+	if fn, ok := f.callbacks[cKey{"", callbackBeforeState}]; ok {
+		fn(ctx, e)
+		if e.canceled {
+			return CanceledError{e.Err}
+		}
+	}
+	return nil
+}
+
 // leaveStateCallbacks calls the leave_ callbacks, first the named then the
 // general version.
 func (f *FSM) leaveStateCallbacks(ctx context.Context, e *Event) error {
@@ -495,6 +532,7 @@ const (
 	callbackNone int = iota
 	callbackBeforeEvent
 	callbackLeaveState
+	callbackBeforeState
 	callbackEnterState
 	callbackAfterEvent
 )

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -208,6 +208,7 @@ func TestMultipleEvents(t *testing.T) {
 func TestGenericCallbacks(t *testing.T) {
 	beforeEvent := false
 	leaveState := false
+	beforeState := false
 	enterState := false
 	afterEvent := false
 
@@ -223,6 +224,9 @@ func TestGenericCallbacks(t *testing.T) {
 			"leave_state": func(_ context.Context, e *Event) {
 				leaveState = true
 			},
+			"before_enter_state": func(_ context.Context, e *Event) {
+				beforeState = true
+			},
 			"enter_state": func(_ context.Context, e *Event) {
 				enterState = true
 			},
@@ -236,13 +240,14 @@ func TestGenericCallbacks(t *testing.T) {
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
-	if !(beforeEvent && leaveState && enterState && afterEvent) {
+	if !(beforeEvent && leaveState && beforeState && enterState && afterEvent) {
 		t.Error("expected all callbacks to be called")
 	}
 }
 
 func TestSpecificCallbacks(t *testing.T) {
 	beforeEvent := false
+	beforeState := false
 	leaveState := false
 	enterState := false
 	afterEvent := false
@@ -259,6 +264,9 @@ func TestSpecificCallbacks(t *testing.T) {
 			"leave_start": func(_ context.Context, e *Event) {
 				leaveState = true
 			},
+			"before_enter_end": func(_ context.Context, e *Event) {
+				beforeState = true
+			},
 			"enter_end": func(_ context.Context, e *Event) {
 				enterState = true
 			},
@@ -272,7 +280,7 @@ func TestSpecificCallbacks(t *testing.T) {
 	if err != nil {
 		t.Errorf("transition failed %v", err)
 	}
-	if !(beforeEvent && leaveState && enterState && afterEvent) {
+	if !(beforeEvent && leaveState && beforeState && enterState && afterEvent) {
 		t.Error("expected all callbacks to be called")
 	}
 }
@@ -359,6 +367,42 @@ func TestCancelBeforeSpecificEvent(t *testing.T) {
 		},
 		Callbacks{
 			"before_run": func(_ context.Context, e *Event) {
+				e.Cancel()
+			},
+		},
+	)
+	_ = fsm.Event(context.Background(), "run")
+	if fsm.Current() != "start" {
+		t.Error("expected state to be 'start'")
+	}
+}
+
+func TestCancelBeforeGenericState(t *testing.T) {
+	fsm := NewFSM(
+		"start",
+		Events{
+			{Name: "run", Src: []string{"start"}, Dst: "end"},
+		},
+		Callbacks{
+			"before_enter_state": func(_ context.Context, e *Event) {
+				e.Cancel()
+			},
+		},
+	)
+	_ = fsm.Event(context.Background(), "run")
+	if fsm.Current() != "start" {
+		t.Error("expected state to be 'start'")
+	}
+}
+
+func TestCancelBeforeSpecificState(t *testing.T) {
+	fsm := NewFSM(
+		"start",
+		Events{
+			{Name: "run", Src: []string{"start"}, Dst: "end"},
+		},
+		Callbacks{
+			"before_enter_end": func(_ context.Context, e *Event) {
 				e.Cancel()
 			},
 		},


### PR DESCRIPTION
This PR introduces a new `before_enter_state_` callback to the state machine, allowing logic to be executed before transitioning into a new state.
This is useful for performing validations, side effects, or preparation steps prior to state entry, like `before_event callback`
